### PR TITLE
Configure WAVE backend URL and add deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,26 @@ After making changes:
 
 ### Deploying Your Experiment
 
-1. **Upload all files** to your web hosting service (ask your lab manager about this)
-2. **Test the uploaded version** by visiting the URL
-3. **Share the URL** with your research platform (Prolific, MTurk, etc.)
+**Recommended Setup:**
+- Configure your hosting platform to deploy from `release` branch, not `main`
+- Merge to `release` branch only when ready to deploy
+- Keeps development work separate from live experiments
+
+**Pre-Deployment Checklist:**
+1. **Test local logging**: Run experiment locally with WAVE URL parameters, verify data appears in console
+2. **Validate parameters**: Check that JSPsych logged parameters match your experiment configuration in `params.js`
+
+**Deploy Steps:**
+1. **Test the deployed version** by visiting your live URL both without and with full parameters
+- `key=YOUR_API_KEY` (⚠️ **Use experimentee-level API key, NOT researcher-level**)
+- `experiment_id=YOUR_EXPERIMENT_ID` 
+- `participant_id=YOUR_PARTICIPANT_ID`
+2. **Share the URL** with your research platform, making sure that when it is distributed to participants it includes the above parameters:
+   ```
+   https://your-experiment.vercel.app/?key=YOUR_API_KEY&experiment_id=YOUR_EXPERIMENT_ID&participant_id=YOUR_PARTICIPANT_ID
+   ```
+
+Refer to Vercel/Cloudflare Pages/GitHub Pages documentation for platform-specific setup.
 
 ## File Structure Explained
 

--- a/docs/setup/wave-integration.md
+++ b/docs/setup/wave-integration.md
@@ -16,6 +16,20 @@ This JSPsych experiment template has been integrated with the WAVE client for au
    - `experiment_id` - The experiment UUID from WAVE backend
    - `participant_id` - Unique identifier for each participant
 
+## Backend Configuration
+
+The WAVE backend URL is configured in `src/js/core/params.js`:
+
+```javascript
+// WAVE Backend Configuration  
+var waveBackendUrl = 'https://wave-backend-production-8781.up.railway.app';
+// var waveBackendUrl = 'http://localhost:8000';  // For local development
+```
+
+To switch between production and development:
+- **Production**: Use the Railway URL (default)
+- **Development**: Comment out production line, uncomment localhost line
+
 ## Quick Start
 
 ### Step 1: Set up your experiment in WAVE backend
@@ -83,7 +97,10 @@ Then open: `http://localhost:8080/`
 - Check URL parameter spelling and format
 
 **Backend connection failed:**
-- Verify WAVE backend is running (default: localhost:8000)  
+- Check the backend URL is correct in `src/js/core/params.js`
+- For production: `waveBackendUrl = 'https://wave-backend-production-8781.up.railway.app'`
+- For local development: `waveBackendUrl = 'http://localhost:8000'`
+- Verify WAVE backend is running and accessible
 - Check network connectivity
 - Verify API key permissions
 

--- a/src/js/core/params.js
+++ b/src/js/core/params.js
@@ -23,6 +23,9 @@ var participantType = 'prolific';
 var completionCode = 'C4MF2IV1';
 var prolific_url = 'https://app.prolific.co/submissions/complete?cc='+completionCode;
 
+// WAVE Backend Configuration
+var waveBackendUrl = 'https://wave-backend-production-8781.up.railway.app';
+// var waveBackendUrl = 'http://localhost:8000';  // For local development
 
 // initializing variables
 var timelinebase = [];

--- a/src/js/integrations/wave-client.js
+++ b/src/js/integrations/wave-client.js
@@ -54,7 +54,7 @@ function initializeWaveClient() {
     try {
         waveClient = new WaveClient({
             apiKey: WAVE_API_KEY,
-            baseUrl: 'http://localhost:8000'  // Default WAVE backend URL
+            baseUrl: waveBackendUrl
         });
 
         // Test connection


### PR DESCRIPTION
## Changes

- Configure WAVE backend URL in `src/js/core/params.js` (defaults to Railway production)
- Update `wave-client.js` to use configurable backend URL instead of hardcoded localhost
- Add deployment documentation recommending release branch strategy
- Include pre-deployment checklist and URL parameter format
- Add security warning for experimentee-level API keys